### PR TITLE
Fixed compilation errors for gcc >= 7

### DIFF
--- a/src/object_store/ObjectStore.h
+++ b/src/object_store/ObjectStore.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <functional>
 
 #include "client/BladeClient.h"
 

--- a/src/server/TCPServerMain.cpp
+++ b/src/server/TCPServerMain.cpp
@@ -31,6 +31,9 @@ auto main(int argc, char *argv[]) -> int {
         case 4:
             {
                 storage_path = argv[3];
+#if __GNUC__ >= 7
+                [[fallthrough]];
+#endif
             }
         case 3:
             {
@@ -38,6 +41,9 @@ auto main(int argc, char *argv[]) -> int {
                     throw std::runtime_error("Wrong backend type");
                 }
                 backend_type = argv[2];
+#if __GNUC__ >= 7
+                [[fallthrough]];
+#endif
             }
         case 2:
             {
@@ -48,6 +54,9 @@ auto main(int argc, char *argv[]) -> int {
                 }
 
                 pool_size *= MB;
+#if __GNUC__ >= 7
+                [[fallthrough]];
+#endif
             }
         case 1:
             break;

--- a/src/utils/Log.h
+++ b/src/utils/Log.h
@@ -74,7 +74,7 @@ bool LOG(Params&& ... param) {
         << " -";
 
 #if __GNUC__ >= 7
-    if constexpr (std::is_same(TT, TIME)) {
+    if constexpr (std::is_same_v<TT, TIME>) {
         std::cout << getTimeNow();
     }
 #else
@@ -89,7 +89,7 @@ bool LOG(Params&& ... param) {
     int dummy[] = { 0, ( (void) f(std::forward<Params>(param)), 0) ... };
 
 #if __GNUC__ >= 7
-    if constexpr (std::is_same(K, FLUSH)) {
+    if constexpr (std::is_same_v<K, FLUSH>) {
         std::cout << std::endl;
     }
 #else


### PR DESCRIPTION
Because of the -Werror flag, switch case fallthroughs are errors, so we need an attribute to explicitly tell the compiler this is okay. Also, we were missing a <functional> include and std::is_same was used incorrectly. None of these were caught earlier because we weren't using a compiler with __GNUC__ >= 7.